### PR TITLE
Changes to use newer pcl and vtk versions and to run 3D Forest also on Linux OSs

### DIFF
--- a/sourceCode/README.txt
+++ b/sourceCode/README.txt
@@ -4,12 +4,14 @@ Published under terms ofGnu/GPL v3 licence.
 created by: Jan trochta j.trochta@gmail.com
 
 INSTALLATION
-	For successfull compilation  from source are needed those libraries:
-	PCL 1.6 and Qt 4.8 with all dependencies (VTK, Eigen, Boost, Flann)
-	or You can use already comlided libraries which are attached in compiled application. 
-	Application was build with mingw-w64
+	For successful compilation from source are needed those libraries:
+	Qt 5.x, Eigen, Boost, Flann, libLAS, VTK 9.x, PCL > 1.11.
 	
-	For installation of compiled application only unzip into the folder you want (c:/3DForest)
+	For Linux OSs, you can download compiled libraries from official Linux repositories (e.g. using apt, dnf...). 
+	
+	For Windows OSs, you can use already compiled libraries which are attached in compiled application.
+	Application was build with mingw-w64.	
+	Or you can install compiled application only unzip into the folder you want (c:/3DForest)
 	and launch app with 3dforest.exe file. 
 
 

--- a/sourceCode/README.txt
+++ b/sourceCode/README.txt
@@ -5,9 +5,9 @@ created by: Jan trochta j.trochta@gmail.com
 
 INSTALLATION
 	For successful compilation from source are needed those libraries:
-	Qt 5.x, Eigen, Boost, Flann, libLAS, VTK 9.x, PCL > 1.11.
+	Qt 5.x, Eigen, Boost, Flann, libLAS, VTK 9.x, PCL >= 1.11.
 	
-	For Linux OSs, you can download compiled libraries from official Linux repositories (e.g. using apt, dnf...). 
+	For Linux OSs, you can download compiled libraries from official Linux repositories (e.g. using apt, dnf, etc.). 
 	
 	For Windows OSs, you can use already compiled libraries which are attached in compiled application.
 	Application was build with mingw-w64.	

--- a/sourceCode/alphaShapes.cpp
+++ b/sourceCode/alphaShapes.cpp
@@ -1,5 +1,4 @@
 #include "alphaShapes.h"
-#include <QVTKWidget.h>
 #include <vtkInteractorStyle.h>
 #include <vtkPolyDataAlgorithm.h>
 #include <vtkPoints.h>

--- a/sourceCode/main.cpp
+++ b/sourceCode/main.cpp
@@ -24,7 +24,7 @@
 
  int main(int argc, char *argv[])
 {
-    QSurfaceFormat::setDefaultFormat(QVTKOpenGLWidget::defaultFormat());
+    QSurfaceFormat::setDefaultFormat(QVTKOpenGLNativeWidget::defaultFormat());
   QApplication app(argc, argv);
   //Q_INIT_RESOURCE(3dforest);
   app.setOrganizationName("VUKOZ v.v.i.");

--- a/sourceCode/mainwindow.cpp
+++ b/sourceCode/mainwindow.cpp
@@ -32,6 +32,7 @@
 #include <boost/date_time/posix_time/posix_time.hpp>
 #include <boost/random/linear_congruential.hpp>
 #include <boost/random/uniform_int.hpp>
+#include <boost/random/uniform_real.hpp>
 #include <boost/random/variate_generator.hpp>
 #include <boost/random/mersenne_twister.hpp>
 #include <boost/math/special_functions/round.hpp>
@@ -70,7 +71,7 @@
 #include <vtkOrientationMarkerWidget.h>
 #include <vtkRenderer.h>
 #include <vtkPNGWriter.h>
-#include <QVTKOpenGLWidget.h>
+#include <QVTKOpenGLNativeWidget.h>
 #include <vtkInteractorStyle.h>
 #include <vtkGenericOpenGLRenderWindow.h>
 #include <vtkRenderer.h>
@@ -104,16 +105,18 @@ BOOST_FUSION_ADAPT_STRUCT(double3, (double, x)(double, y)(double, z))
     setWindowTitle ( tr("3D Forest - Forest Lidar Data Processing Tool") );
 
 //QVTKwidget - visualizer
-    qvtkwidget = new QVTKOpenGLWidget(this);
+    qvtkwidget = new QVTKOpenGLNativeWidget(this);
 
     auto renderer = vtkSmartPointer<vtkRenderer >::New();
     auto renderWindow = vtkSmartPointer<vtkGenericOpenGLRenderWindow >::New();
-
+    auto style = vtkSmartPointer<pcl::visualization::PCLVisualizerInteractorStyle>::New();
+    
     renderWindow->AddRenderer(renderer);
     
-    m_vis = new pcl::visualization::PCLVisualizer(renderer, renderWindow, "data viewer", true);
+    m_vis = new pcl::visualization::PCLVisualizer(renderer, renderWindow, "data viewer", false);
     m_vis->setShowFPS(false);
-    qvtkwidget->SetRenderWindow(m_vis->getRenderWindow());
+    qvtkwidget->setRenderWindow(m_vis->getRenderWindow());
+    m_vis->setupInteractor(qvtkwidget->interactor()->GetInteractorStyle()->GetInteractor(), qvtkwidget->renderWindow());
     coordianteAxes();
     setCentralWidget(qvtkwidget);
     qvtkwidget->show();
@@ -7142,7 +7145,7 @@ void MainWindow::AreaEvent(const pcl::visualization::AreaPickingEvent& event, vo
     auto name = (m_cloud->get_name().toStdString());
     auto indices = event.getPointsIndices(name);
 
-    boost::shared_ptr<std::vector<int> > indicesptr (new std::vector<int> (indices));
+    std::shared_ptr<std::vector<int> > indicesptr (new std::vector<int> (indices));
     pcl::PointCloud<pcl::PointXYZI>::Ptr cloud2 (new pcl::PointCloud<pcl::PointXYZI>);
     pcl::PointCloud<pcl::PointXYZI>::Ptr cloud1 (new pcl::PointCloud<pcl::PointXYZI>);
     undopoint.push_back(indices.size());

--- a/sourceCode/mainwindow.h
+++ b/sourceCode/mainwindow.h
@@ -16,8 +16,7 @@
 #ifndef MAINWINDOW_H_INCLUDED
 #define MAINWINDOW_H_INCLUDED
 
-#include <QVTKOpenGLWidget.h>
-#include <QVTKWidget.h>
+#include <QVTKOpenGLNativeWidget.h>
 #include <QtWidgets/QMainWindow>
 #include "gui.h"
 #include "project.h"
@@ -492,7 +491,7 @@ private:
 
 //QVTKWIDGET - display and hide clouds
   //QVTKWidget *qvtkwidget;
-    QVTKOpenGLWidget *qvtkwidget;
+    QVTKOpenGLNativeWidget *qvtkwidget;
     /**< Define QVTKWidget */
   //Visualizer *m_vis;
     pcl::visualization::PCLVisualizer *m_vis; /**< Visualizer */
@@ -611,7 +610,8 @@ private:
   QMenu *crownMenu;           /**< Crown menu */
   QMenu *helpMenu;            /**< About menu */
   QMenu *miscMenu;            /**< Other features menu */
-    QMenu *qsmMenu;
+  QMenu *milireMenu;
+  QMenu *qsmMenu;
 
 //PROJECT ACTIONS
   QAction *new_projectAct;    /**< New project Act */

--- a/sourceCode/project.cpp
+++ b/sourceCode/project.cpp
@@ -24,7 +24,7 @@
 #include <pcl/io/vtk_io.h>
 #include <iostream>
 //#include <string>
-#include <QtCore/QString.h>
+#include <QtCore/qstring.h>
 #include <QtWidgets/QMessageBox>
 #include <QtWidgets/QCheckBox>
 #include <QtWidgets/QRadioButton>

--- a/sourceCode/reconstruction.cpp
+++ b/sourceCode/reconstruction.cpp
@@ -3,6 +3,8 @@
 
 #include <pcl/filters/extract_indices.h>
 #include <pcl/common/pca.h>
+#include <pcl/octree/octree_search.h>
+#include <pcl/search/octree.h>
 
 //BOOOST
 #include <boost/graph/adjacency_list.hpp>

--- a/sourceCode/segmentation.cpp
+++ b/sourceCode/segmentation.cpp
@@ -601,7 +601,7 @@ void Segmentation::reconstructVegetationRest()
             indices.insert(indices.end(), m_clusters.at(element.at(a)).begin(),m_clusters.at(element.at(a)).end());
     }
     
-    boost::shared_ptr<std::vector<int> > indicesptr (new std::vector<int> (indices));
+    std::shared_ptr<std::vector<int> > indicesptr (new std::vector<int> (indices));
     pcl::ExtractIndices<pcl::PointXYZI> extract;
     extract.setInputCloud (m_vegetation->get_Cloud());
     extract.setIndices (indicesptr);
@@ -631,7 +631,7 @@ void Segmentation::reconstructElement(std::vector<int> element)
     if(m_vegetation->get_Cloud()->points.size() < indices.size()  || indices.size() ==0)
         return;
     
-    boost::shared_ptr<std::vector<int> > indicesptr (new std::vector<int> (indices));
+    std::shared_ptr<std::vector<int> > indicesptr (new std::vector<int> (indices));
     pcl::ExtractIndices<pcl::PointXYZI> extract;
     extract.setInputCloud (m_vegetation->get_Cloud());
     extract.setIndices (indicesptr);

--- a/sourceCode/segmentation.h
+++ b/sourceCode/segmentation.h
@@ -4,6 +4,7 @@
 #include <pcl/pcl_base.h>
 #include <pcl/point_types.h>
 #include <pcl/common/common_headers.h>
+#include <pcl/octree/octree_search.h>
 #include "cloud.h"
 #include <QtCore/QObject>
 

--- a/sourceCode/skeleton.cpp
+++ b/sourceCode/skeleton.cpp
@@ -573,7 +573,7 @@ void Skeleton::mergeTreeSets(std::vector<std::vector<int>>& sets, pcl::PointClou
         std::chrono::system_clock::to_time_t(now);
        // start = std::time(nullptr);
         // set octree search
-        boost::shared_ptr<std::vector<int> > indicesptr (new std::vector<int> (sets.at(bigSegmentID)));
+        std::shared_ptr<std::vector<int> > indicesptr (new std::vector<int> (sets.at(bigSegmentID)));
        // std::cout<< "veliksot indices: "<< sets.at(bigSegmentID).size()<<"\n";
         search.setInputCloud (cloud, indicesptr);
         search.addPointsFromInputCloud ();

--- a/sourceCode/terrain.cpp
+++ b/sourceCode/terrain.cpp
@@ -8,6 +8,8 @@
 #include <pcl/filters/radius_outlier_removal.h>
 #include <pcl/common/centroid.h>
 #include <pcl/common/pca.h>
+#include <pcl/octree/octree_search.h>
+
  OctreeTerrain::OctreeTerrain()
 {
   m_baseCloud = new Cloud();
@@ -112,7 +114,7 @@ void OctreeTerrain::octree(float res, pcl::PointCloud<pcl::PointXYZI>::Ptr input
   ocsearch.deleteTree();
  // ocs.voxelSearch(voxels.at(q),low_voxels_indices);
 
-    boost::shared_ptr<std::vector<int> > indicesptr (new std::vector<int> (low_voxels_indices));
+    std::shared_ptr<std::vector<int> > indicesptr (new std::vector<int> (low_voxels_indices));
     pcl::ExtractIndices<pcl::PointXYZI> extract;
      // Extract the inliers
     extract.setInputCloud (input);
@@ -170,7 +172,7 @@ std::vector<int> pointID_ground;
       }
     }
 emit percentage( 60);
-    boost::shared_ptr<std::vector<int> > indices_ground (new std::vector<int> (pointID_ground));
+    std::shared_ptr<std::vector<int> > indices_ground (new std::vector<int> (pointID_ground));
     pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_ground(new pcl::PointCloud<pcl::PointXYZI>);
     pcl::ExtractIndices<pcl::PointXYZI> extract;
        // Extract the inliers
@@ -213,7 +215,7 @@ emit percentage( 70);
     }
 emit percentage( 80);
     pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_vege(new pcl::PointCloud<pcl::PointXYZI>);
-    boost::shared_ptr<std::vector<int> > indicesptr (new std::vector<int> (pointIDS));
+    std::shared_ptr<std::vector<int> > indicesptr (new std::vector<int> (pointIDS));
     pcl::ExtractIndices<pcl::PointXYZI> e;
        // Extract the inliers
     e.setInputCloud (m_baseCloud->get_Cloud());
@@ -368,7 +370,7 @@ emit percentage( 40);
 
   // jeste by to chtelo trochu prefiltrovat aby byl opravdu jen voxely terenu
 
-  boost::shared_ptr<std::vector<int> > indicesptr (new std::vector<int> (low_voxels));
+  std::shared_ptr<std::vector<int> > indicesptr (new std::vector<int> (low_voxels));
   pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_vege (new pcl::PointCloud<pcl::PointXYZI>);
   pcl::PointCloud<pcl::PointXYZI>::Ptr cloud_terrain (new pcl::PointCloud<pcl::PointXYZI>);
   pcl::ExtractIndices<pcl::PointXYZI> extract;


### PR DESCRIPTION
I added `milireMenu` in QMenu functions that missed in original source code on master branch and i changed `QtCore/QString.h` to `QtCore/qstring.h` for Qt 5.x versions.
To use newer pcl and vtk versions, i've done some changes:

- From 1.11 pcl version, **boost shared pointers** have been replaced with **std shared pointers**, so i applied these replacements in the original source code. I also added some pcl header includes that were missing.
- From 9.0 vtk version, **QVTKOpenGLWidget** was deprecated and replaced with **QVTKOpenGLNativeWidget** and **QVTKOpenGLStereoWidget**. So in source code, i changed **QVTKOpenGLWidget** with **QVTKOpenGLNativeWidget** that is a Qt native widget and works fine in Qt applications, but doesn't support stereo rendering unlike **QTVKOpenGLStereoWidget** (based on QVTKOpenGLWidget but with some possible problems with some Qt actions).

Finally, i setted the `create_interactor` function of pcl visualizer to `false` because _qvtkwidget_ previously created in source code is already an interactor and if it's created, in Linux systems 3D Forest compiled crashes when it runs with segfault message (i tried on Ubuntu 22.04 #33 and also on Fedora 37 with same problem). Then i created a new default style of pcl interactor that i've assigned to _qvtkwidget_, because without the creation of pcl interactor there isn't a default interactor style and then, the use of keyboard keys won't activate the related functions.