### PR TITLE
3D Forest compiled on Windows and Linux

### DIFF
--- a/sourceCode/README.txt
+++ b/sourceCode/README.txt
@@ -4,14 +4,13 @@ Published under terms ofGnu/GPL v3 licence.
 created by: Jan trochta j.trochta@gmail.com
 
 INSTALLATION
+	
 	For successful compilation from source are needed those libraries:
-	Qt 5.x, Eigen, Boost, Flann, libLAS, VTK 9.x, PCL >= 1.11.
+	Qt 5.x, Eigen, Boost, Flann, Qhull, libusb 1.0, libLAS, VTK 9.x, PCL >= 1.11.
 	
-	For Linux OSs, you can download compiled libraries from official Linux repositories (e.g. using apt, dnf, etc.). 
+	For Linux OSs, you can download Qt 5.x, Eigen, Boost, Flann, Qhull, libusb 1.0 from official Linux repositories (e.g. using apt, dnf, etc.). Then you have to compile libLAS, vtk and pcl source code with Qt support, or you can use these library already compiled which are attached in compressed folder of 3D forest compiled.
 	
-	For Windows OSs, you can use already compiled libraries which are attached in compiled application.
-	Application was build with mingw-w64.	
-	Or you can install compiled application only unzip into the folder you want (c:/3DForest)
-	and launch app with 3dforest.exe file. 
-
-
+	For Windows OSs, you can install Qt with the qt online installer (https://www.qt.io/download-qt-installer?hsCtaTracking=99d9dd4f-5681-48d2-b096-470725510d34%7C074ddad0-fdef-4e53-8aa8-5e8a876d6ab4).
+	To compile Eigen, Boost, Flann, Qhull, libusb 1.0 and libLAS you can use vcpkg repository and msvc v142 (Visual Studio 2019), for vtk and pcl you have to compile the source codes with Qt support.
+	3D Forest was also compiled with msvc v142.	
+	Or you can install compiled application where you want with Windows installer file (.msi).


### PR DESCRIPTION
I updated the installation instructions for both Windows and Linux.
To compile requested libraries and 3D Forest with newer vtk and pcl versions on Windows, I used vcpkg packages manager and msvc v142 (Visual Studio 2019). So if you want to add all the packages (3D Forest windows installer .msi, compressed folder with app compiled and installation instructions for Linux and source code for Windows in which there is the cmakefile.txt with a modify to search libLAS) in Release section, they are in v052 tag of my forked repository.